### PR TITLE
fix UIStoryboard extension for init with PStoryBoard should be public…

### DIFF
--- a/CHICore/Classes/Helpers/PStoryboardHelpers.swift
+++ b/CHICore/Classes/Helpers/PStoryboardHelpers.swift
@@ -22,7 +22,7 @@ public protocol PStoryBoard {
     func name() -> String
 }
 
-extension UIStoryboard {
+public extension UIStoryboard {
     
     convenience init(storyboard: PStoryBoard, bundle: Bundle? = nil) {
         self.init(name: storyboard.name(), bundle: bundle)


### PR DESCRIPTION
… to be accessible outside of module scope
@chili-ios  